### PR TITLE
feat: whenQuery supports field nested query

### DIFF
--- a/publish/elasticsearch.php
+++ b/publish/elasticsearch.php
@@ -8,6 +8,6 @@ return [
     'default' => [
         'hosts' => [env('ELASTICSEARCH_HOST', 'http://127.0.0.1:9200')],
         'max_connections' => 50,
-        'timeout' => 2.0
-    ]
+        'timeout' => 2.0,
+    ],
 ];

--- a/tests/ClientFactoryTest.php
+++ b/tests/ClientFactoryTest.php
@@ -16,7 +16,7 @@ class ClientFactoryTest extends TestCase
 {
     public function testClientBuilderFactoryCreate()
     {
-        $clientFactory =  ApplicationContext::getContainer()->get(Client::class);
+        $clientFactory = ApplicationContext::getContainer()->get(Client::class);
 
         $client = $clientFactory->create();
 


### PR DESCRIPTION
`whenQuery`获取 `searchFields`的时候,如果 mapping嵌套,是无法支持嵌套的字段查询,比如这里的 `extend.other.column0`无法被查询

```php
[
     "properties"=>[
        "id" => [
            "type" => "integer"
        ],
        "extend" => [
            "properties" => [
                "other" => [
                    "properties" => [
                        "column0" => [
                            "type" => "integer"
                        ],
                    ],
                ],
            ],
        ],
    ],
]
```

```php
  public static function whenQuery(array $params)
  {
      $searchFields = array_keys((new static())->getMapping()['properties'] ?? []);
      return self::when($params, function (Builder $query) use ($params, $searchFields) {
          foreach ($params as $item) {
              [$field, $operator, $value] = $item;
              if (! in_array($field, $searchFields)) {
                  continue;
              }
              if ($operator == 'geo') {
                  $query->geo((float) $value['lat'], (float) $value['lng'], distance: $value['distance'] ?? 2000)
                      ->orderByGeo((float) $value['lat'], (float) $value['lng']);
              } else {
                  $query->where($field, $operator, $value);
              }
          }
      });
    }
```

增加了递归遍历 `mapping`字段方法,获取所有字段来进行查询