### PR TITLE
fix: fix where query

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -668,14 +668,12 @@ class Builder
     {
         return match ($operate) {
             'like' => ['match' => [$field => $value]],
-            '=' => ['term' => [$field => $value]],
+            '=', '<>', '!=' => ['term' => [$field => $value]],
             '>' => ['range' => [$field => ['gt' => $value]]],
             '<' => ['range' => [$field => ['lt' => $value]]],
             '>=' => ['range' => [$field => ['gte' => $value]]],
             '<=' => ['range' => [$field => ['lte' => $value]]],
-            '<>', '!=' => ['match' => [$field => $value]],
-            'in' => ['terms' => [$field => $value]],
-            'not in' => ['terms' => [$field => $value]],
+            'in', 'not in' => ['terms' => [$field => $value]],
             'regex' => ['regexp' => [$field => $value]],
             'prefix' => ['prefix' => [$field => $value]],
             'nested' => ['nested' => ['path' => $field, 'query' => $value]],

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -645,14 +645,14 @@ class Builder
         match ($operate) {
             'like',
             '=',
-            '>' ,
-            '<' ,
-            '>=' ,
-            '<=' ,
+            '>',
+            '<',
+            '>=',
+            '<=',
             'in',
-            'regex' ,
-            'prefix' ,
-            'multi match' ,
+            'regex',
+            'prefix',
+            'multi match',
             'range' => $this->query['bool']['must'][] = $parsedOperation,
             'nested' => $this->query['bool']['filter'][] = $parsedOperation,
             '<>', '!=',
@@ -667,7 +667,8 @@ class Builder
     protected function parseOperation(string $field, string $operate, mixed $value): array
     {
         return match ($operate) {
-            'like', '=' => ['match' => [$field => $value]],
+            'like' => ['match' => [$field => $value]],
+            '=' => ['term' => [$field => $value]],
             '>' => ['range' => [$field => ['gt' => $value]]],
             '<' => ['range' => [$field => ['lt' => $value]]],
             '>=' => ['range' => [$field => ['gte' => $value]]],


### PR DESCRIPTION
Fix using `$query->where('column',value)` should be resolved to `term` instead of `match`